### PR TITLE
Exclude gradle build directory

### DIFF
--- a/data/gitignore/Custom/Gradle.gitignore
+++ b/data/gitignore/Custom/Gradle.gitignore
@@ -1,2 +1,3 @@
 # Exclude Folder List #
 .gradle/
+build/


### PR DESCRIPTION
The default output folder for gradle is a build/ directory. Makes sense to exclude this folder because gradle can generate everything inside the folder.
