### PR TITLE
Added some files to netbeans

### DIFF
--- a/data/gitignore/Global/NetBeans.gitignore
+++ b/data/gitignore/Global/NetBeans.gitignore
@@ -1,7 +1,9 @@
-nbproject/private/
+nbproject/
 build/
 nbbuild/
 dist/
 nbdist/
 nbactions.xml
 nb-configuration.xml
+build.xml
+build.properties


### PR DESCRIPTION
Different projects use different configurations.

`nbproject/private` was changed to `nbproject/` because some projects still hold files in `nbprojects`. I don't think anyone wants those files committed.
