### PR TITLE
Ignore rope files.

### DIFF
--- a/data/gitignore/Python.gitignore
+++ b/data/gitignore/Python.gitignore
@@ -34,3 +34,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# Rope
+.ropeproject


### PR DESCRIPTION
Rope (https://bitbucket.org/zjes/rope_py3k/overview) is a refactoring tool for Python. It creates temporary files in `.ropeproject` to cache data. These files should be ignored by default.
