### PR TITLE
Added .gitignore file for Xcode

### DIFF
--- a/data/gitignore/Global/Xcode.gitignore
+++ b/data/gitignore/Global/Xcode.gitignore
@@ -1,0 +1,4 @@
+build
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcworkspace/contents.xcworkspacedata


### PR DESCRIPTION
Refered following sites (Japanese sites);
- http://moomindani.wordpress.com/2012/08/05/xcode%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E7%94%A8%E3%81%AE-gitignore%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B/
- http://qiita.com/Potof_/items/53b363a7f0d49f614b4c
- http://objective-c.otokodate.net/ios%E3%82%A2%E3%83%97%E3%83%AA%E9%96%8B%E7%99%BA/gitignore-for-xcode/

I thought that `build` directory also should be ignored, so I added it.
