### PR TITLE
Updated gitignore for objective-c to include cocoa pods and xcode 5

### DIFF
--- a/data/gitignore/Objective-C.gitignore
+++ b/data/gitignore/Objective-C.gitignore
@@ -1,6 +1,8 @@
-# Xcode
+# OS X
 .DS_Store
-*/build/*
+
+# Xcode
+build/
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -10,8 +12,12 @@
 *.perspectivev3
 !default.perspectivev3
 xcuserdata
+*.xccheckout
 profile
 *.moved-aside
 DerivedData
-.idea/
 *.hmap
+*.ipa
+
+# CocoaPods
+Pods


### PR DESCRIPTION
Includes cocoa pods and xcode 5
