### PR TITLE
Add file for composer

### DIFF
--- a/data/gitignore/Custom/Composer.gitignore
+++ b/data/gitignore/Custom/Composer.gitignore
@@ -1,4 +1,3 @@
 # Composer - http://getcomposer.org
 /vendor
 composer.phar
-composer.lock


### PR DESCRIPTION
I thought it'd be cool to have a gitignore file for composer with the defaults:
- The `vendor` folder should not be checked in to version control
- The `composer.phar` file is often used to run composer locally but should not be checked into version control
