### PR TITLE
ignore JabRef backup files

### DIFF
--- a/data/custom/JabRef.gitignore
+++ b/data/custom/JabRef.gitignore
@@ -1,0 +1,2 @@
+# JabRef - http://jabref.sourceforge.net/
+*.bib.bak


### PR DESCRIPTION
It's useful in Latex project for those who maintain the bibliography with JabRef (http://jabref.sourceforge.net/).
