### PR TITLE
Updated Laravel .gitignore

### DIFF
--- a/data/custom/Laravel.gitignore
+++ b/data/custom/Laravel.gitignore
@@ -1,3 +1,6 @@
+/bootstrap/compiled.php
 /vendor
+.env.local.php
+.env.php
 composer.phar
 composer.lock


### PR DESCRIPTION
Laravel suggests to add the .env.php (and .env.local.php) files to the gitignore as they are used for 'sensitive configuration' :  [Laravel Documentation](http://laravel.com/docs/configuration#protecting-sensitive-configuration) 

The /bootstrap/compiled.php file should also be added in the gitignore (caching stuff, double check in [Laravel official gitignore](https://github.com/laravel/laravel/blob/master/.gitignore) , you'll see it's there)
