### PR TITLE
Correct a small typo on the CLI page

### DIFF
--- a/views/cli.jade
+++ b/views/cli.jade
@@ -47,7 +47,7 @@ block content
             span.nb source&nbsp;
             | ~/.zshrc
           h3.spacer.windows-logo Windows
-          p Crate a PowerShell v3 Script
+          p Create a PowerShell v3 Script
           pre.highlight
             span.c #For PowerShell v3
             br
@@ -98,7 +98,7 @@ block content
             span.n ascii
             br
             span.p }
-          p Crate a PowerShell v2 Script
+          p Create a PowerShell v2 Script
           pre.highlight
             span.c #For PowerShell v2
             br


### PR DESCRIPTION
This just patches a tiny couple of typos on the CLI page (Crate -> Create)
