### PR TITLE
Updates options for Less Middleware 1.0.x

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ app.use(app.router);
 app.use(ua.middleware(process.env.GA_TRACKING_ID, {cookieName: '_ga'}));
 app.use(express.static(path.join(__dirname, 'public'), { maxAge: oneDay }));
 app.use(require('uglify-js-middleware')({ src: path.join(__dirname,'public') }));
-app.use(require('less-middleware')({ src: path.join(__dirname,'public'),compress: true }));
+app.use(require('less-middleware')(path.join(__dirname,'public'), [], [], [{compress: true}]));
 
 // development only
 if ('development' == app.get('env')) {


### PR DESCRIPTION
As per http://goo.gl/lLphiC

I was getting an error upon running `node app.js`:

```
/Users/USER/workspace/javascript/gitignore.io/node_modules/less-middleware/lib/middleware.js:51
    throw new Error('Please update your less-middleware usage: http://goo.gl/a
          ^
Error: Please update your less-middleware usage: http://goo.gl/aXuck7
    at module.exports.less.middleware (/Users/USER/workspace/javascript/gitignore.io/node_modules/less-middleware/lib/middleware.js:51:11)
    at Object.<anonymous> (/Users/USER/workspace/javascript/gitignore.io/app.js:36:35)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```

And this fixed it.

Cheers!
