### PR TITLE
Revert "Added composer.lock file"

### DIFF
--- a/data/custom/Composer.gitignore
+++ b/data/custom/Composer.gitignore
@@ -1,4 +1,3 @@
 # Composer - http://getcomposer.org
 /vendor
 composer.phar
-composer.lock


### PR DESCRIPTION
Fixes #54.

The file composer.lock should **not** be ignored by Git! The file should be committed into version control to ensure that everybody uses the same versions of dependencies.

See for instance https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file and http://adamcod.es/2013/03/07/composer-install-vs-composer-update.html.

The line was introduced by ec5d0c0 (pull request #49). This pull request simply reverts that commit.
