### PR TITLE
Ignore /log and /temp directories content but commit .htaccess files

### DIFF
--- a/data/custom/Nette.gitignore
+++ b/data/custom/Nette.gitignore
@@ -1,3 +1,6 @@
 # Nette - http://nette.org
-/temp
-/log
+# Ignore /log and /temp directories content but commit .htaccess settings
+/log/*
+!/log/.htaccess
+/temp/*
+!/temp/.htaccess


### PR DESCRIPTION
Apache .htaccess files in /log and /temp directories denies access to these directories and these files should be part of the repository.
