### PR TITLE
Issue #56: Re-added the escape of '' in cli OSX docs.

### DIFF
--- a/views/cli.jade
+++ b/views/cli.jade
@@ -37,7 +37,7 @@ block content
           pre.highlight
             span.nv $&nbsp;
             span.nb echo&nbsp;
-            span.s2 "function gi() { curl http://www.gitignore.io/api/$@ ;}"&nbsp;
+            span.s2 "function gi() { curl http://www.gitignore.io/api/\$@ ;}"&nbsp;
             | >> ~/.bash_profile&nbsp;
             span.o &&&nbsp;
             span.nb source&nbsp;
@@ -46,7 +46,7 @@ block content
           pre.highlight
             span.nv $&nbsp;
             span.nb echo&nbsp;
-            span.s2 "function gi() { curl http://www.gitignore.io/api/$@ ;}"&nbsp;
+            span.s2 "function gi() { curl http://www.gitignore.io/api/\$@ ;}"&nbsp;
             | >> ~/.zshrc&nbsp;
             span.o &&&nbsp;
             span.nb source&nbsp;


### PR DESCRIPTION
The escape character should only be used when writing to file from the command line. If the function is created in the command line but not added to a configuration file (like ~/.bash_profile), then the use of the escape character will cause issues.
