### PR TITLE
added template for Google App Engine

### DIFF
--- a/data/custom/AppEngine.gitignore
+++ b/data/custom/AppEngine.gitignore
@@ -1,0 +1,3 @@
+# Google App Engine - https://developers.google.com/appengine/
+appengine-generated/
+


### PR DESCRIPTION
This template will ignore the appengine-generated folder that is created when a local running App Engine instance accesses the datastore. 

See the "Using the Datastore" section of : 

https://developers.google.com/appengine/docs/java/tools/devserver
