### PR TITLE
SilverStripe - Ignore (optional) silverstripe-cache folder

### DIFF
--- a/data/custom/Silverstripe.gitignore
+++ b/data/custom/Silverstripe.gitignore
@@ -1,3 +1,4 @@
 assets/_combinedfiles/
 assets/_resampled/
 assets/Uploads/
+silverstripe-cache/


### PR DESCRIPTION
The silverstripe-cache folder can be added to the web root. This folder will then be used for template cache and the Manifest, rather than the TEMP_DIR (usually /tmp). Often this is necessary in load balanced environments where the TEMP_DIR is unique to each instance but the webroot is shared.
