### PR TITLE
Create grunt.gitignore

### DIFF
--- a/data/custom/grunt.gitignore
+++ b/data/custom/grunt.gitignore
@@ -1,0 +1,5 @@
+# Grunt usually compiles files inside this directory
+dist/
+
+# Grunt usually preprocesses files such as coffeescript, compass... inside the .tmp directory
+.tmp/


### PR DESCRIPTION
Most of the grunt configurations create .tmp and dist directories that are not supposed to be pushed into git repositories.
