### PR TITLE
Remove custom Composer.gitignore

### DIFF
--- a/data/custom/Composer.gitignore
+++ b/data/custom/Composer.gitignore
@@ -1,3 +1,0 @@
-# Composer - http://getcomposer.org
-/vendor
-composer.phar


### PR DESCRIPTION
Composer.gitignore in github/gitignore is identical.
github/gitignore version is preferred, and it includes information about the composer.lock file.
