### PR TITLE
Update documentation to follow redirection headers from server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,28 +14,28 @@ To run gitignore.io from your command line you need an active internet connectio
 ## Git
 `#!/bin/bash`
 ```sh
-$ git config --global alias.test '!gi() { curl -s https://www.gitignore.io/api/$@ ;}; gi'
+$ git config --global alias.test '!gi() { curl -L -s https://www.gitignore.io/api/$@ ;}; gi'
 ```
 
 ## Linux
 `#!/bin/bash`
 ```sh
-$ echo "function gi() { curl -s https://www.gitignore.io/api/\$@ ;}" >> ~/.bashrc && source ~/.bashrc
+$ echo "function gi() { curl -L -s https://www.gitignore.io/api/\$@ ;}" >> ~/.bashrc && source ~/.bashrc
 ```
 
 `#!/bin/zsh`
 ```sh
-$ echo "function gi() { curl -s https://www.gitignore.io/api/\$@ ;}" >> ~/.zshrc && source ~/.zshrc
+$ echo "function gi() { curl -L -s https://www.gitignore.io/api/\$@ ;}" >> ~/.zshrc && source ~/.zshrc
 ```
 
 ## OSX
 `#!/bin/bash`
 ```sh
-$ echo "function gi() { curl -s https://www.gitignore.io/api/\$@ ;}" >> ~/.bash_profile && source ~/.bash_profile
+$ echo "function gi() { curl -L -s https://www.gitignore.io/api/\$@ ;}" >> ~/.bash_profile && source ~/.bash_profile
 ```
 `#!/bin/zsh`
 ```sh
-$ echo "function gi() { curl -s https://www.gitignore.io/api/\$@ ;}" >> ~/.zshrc && source ~/.zshrc
+$ echo "function gi() { curl -L -s https://www.gitignore.io/api/\$@ ;}" >> ~/.zshrc && source ~/.zshrc
 ```
 
 ## Windows


### PR DESCRIPTION
As I noted in issue #85 since the [universal SSL](http://blog.cloudflare.com/introducing-universal-ssl/) system was turned on at cloudflare anyone using the older function declaration which only used http will get the following html block in stead of their .gitignores.

```
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>cloudflare-nginx</center>
</body>
</html>
```

To prevent this, more for any future instances of server movement, I suggest we add -L to the curl command to follow any redirections indicated by the server.

I tested this with http and it works well. Although there might be some performance hit for the extra steps taken to get the correct endpoint.

There may be a way within your server to detect these changes and prompt the user to update their configuration though. 

This resolves issue #85
