### PR TITLE
Add gitignore for M2Eclipse

### DIFF
--- a/data/custom/m2e.gitignore
+++ b/data/custom/m2e.gitignore
@@ -1,0 +1,2 @@
+.classpath
+.project


### PR DESCRIPTION
I'd like to add an ignore file for M2Eclipse projects.

The .classpath and .project files are derived from the pom.xml when using m2e.

The GitHub gitignore repository doesn't include the files in the Eclipse gitignore because the files are supposed to be committed if you aren't using m2e (see github/gitignore#1211).

See also #80.
