### PR TITLE
Update gitignore to use toptal/gitignore at recent commit (18e7a3d)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "gitignore"]
 	path = gitignore
-	url = https://github.com/dvcs/gitignore.git
+	url = https://github.com/toptal/gitignore.git


### PR DESCRIPTION
this repo uses a very stale gitignore submodule

this PR:
- [x] updates the submodule repo URL
- [x] updates the submodule commit to the most recent value

one issue - recent builds are failing for toptal/gitignore. i think i found a fix; see https://github.com/toptal/gitignore/pull/299.

related: https://github.com/toptal/gitignore.io/pull/476