### PR TITLE
Bump swift from v4.1 to v4.2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:4.1
+FROM swift:4.2.4
 WORKDIR /app
 ADD . ./
 RUN git submodule update --init --recursive


### PR DESCRIPTION
Bumps swift to the latest available version in v4 branch.

To test manually:
```
docker-compose up --build
```
visit http://localhost:8080