### PR TITLE
Fix Icon\r\r

### DIFF
--- a/Sources/App/RouteHandlers/APIRouteHandlers.swift
+++ b/Sources/App/RouteHandlers/APIRouteHandlers.swift
@@ -142,7 +142,7 @@ internal class APIHandlers {
 
                     """
                 }
-                return contents
+                return contents.replacingOccurrences(of: "Icon\r\n", with: "Icon\r\r\n", options: .regularExpression)
             }
             .reduce("""
 


### PR DESCRIPTION
### Description
Fixing the issue outlined in https://github.com/toptal/gitignore.io/issues/504

### How to test:
- Run `docker-compose -f ./docker-compose-dev.yml up --build`
- Visit http://0.0.0.0:8080/api/macos
- To check if `\r\r` is present you can do use `irb`
```
require 'net/http'
require 'uri'
Net::HTTP.get_response(URI.parse("http://0.0.0.0:8080/api/macos")).body
```

You should see two `\r` after Icon:
```
=> "\n# Created by https://www.toptal.com/api/macos\n# Edit at https://www.toptal.com?templates=macos\n\n### macOS ###\n# General\n.DS_Store\n.AppleDouble\n.LSOverride\n\n# Icon must end with two \\r\nIcon\r\r\n\n# Thumbnails\n._*\n\n# Files that might appear in the root of a volume\n.DocumentRevisions-V100\n.fseventsd\n.Spotlight-V100\n.TemporaryItems\n.Trashes\n.VolumeIcon.icns\n.com.apple.timemachine.donotpresent\n\n# Directories potentially created on remote AFP share\n.AppleDB\n.AppleDesktop\nNetwork Trash Folder\nTemporary Items\n.apdisk\n\n# End of https://www.toptal.com/api/macos\n"
```
See `# Icon must end with two \\r\nIcon\r\r\n\n`