### PR TITLE
[TRA-1102] Change Gitignore.io content group implementation

### DIFF
--- a/Public/js/app.js
+++ b/Public/js/app.js
@@ -110,30 +110,3 @@ $(function () {
     }
 });
 
-(function setupAnalytics() {
-    if (!window.GOOGLE_ANALYTICS_UID) {
-        console.error('Google Analytics UID is not set, skipping...');
-        return;
-    }
-
-    var script = document.createElement('script');
-    script.onload = loadAnalytics;
-    script.type = 'text/javascript';
-    script.src = 'https://www.googletagmanager.com/gtag/js?id=' + window.GOOGLE_ANALYTICS_UID;
-    document.getElementsByTagName('head')[0].appendChild(script);
-
-    function loadAnalytics() {
-        window.dataLayer = window.dataLayer || [];
-        function gtag() {
-          dataLayer.push(arguments);
-        };
-        gtag('js', new Date());
-        gtag('config', window.GOOGLE_ANALYTICS_UID, {
-            'content_group1': 'Git Ignore',
-            'custom_map': { 'dimension10': 'client_id' }
-        });
-        setTimeout(function() {
-          gtag('event', 'read', { 'event_category': '15_seconds' });
-        }, 15000);
-    }
-})();

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -34,6 +34,25 @@
     <link rel="stylesheet" type="text/css" href="css/select2-toptal-theme.css">
 
     <link rel="icon" href="favicon.ico" type="image/x-icon">
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-21104039-1"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        
+        gtag('js', new Date());
+
+        gtag('config', 'UA-21104039-1', {
+            'content_group1': 'Git Ignore',
+            'custom_map': { 'dimension10': 'client_id' }
+        });
+
+        setTimeout(function() {
+            gtag('event', 'read', { 'event_category': '15_seconds' });
+        }, 15000);
+    </script>
+    
 </head>
 <body>
     <header>

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -36,14 +36,14 @@
     <link rel="icon" href="favicon.ico" type="image/x-icon">
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-21104039-1"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=#(googleAnalyticsUIDString)"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         
         gtag('js', new Date());
 
-        gtag('config', 'UA-21104039-1', {
+        gtag('config', "#(googleAnalyticsUIDString)", {
             'content_group1': 'Git Ignore',
             'custom_map': { 'dimension10': 'client_id' }
         });


### PR DESCRIPTION
## Description

-  Change Google Analytics Implementation

## How to test

- Check if Google Analytics is still loaded on gitignore.
- Check if `content_group` is `Git Ignore`.