### PR TITLE
fix: Japanese translation

### DIFF
--- a/Localizations/ja.json
+++ b/Localizations/ja.json
@@ -6,10 +6,10 @@
     "searchGo": "作成する",
     "searchDownload": "ファイルをダウンロードする",
     "footer": "%{templateCount} オペレーティングシステム、IDE、プログラミング言語の.gitignoreテンプレート",
-    "commandLineTitle": "コマンドラインド ドキュメンテーション",
+    "commandLineTitle": "コマンドライン ドキュメンテーション",
     "commandLineDescription": "コマンドラインから.gitignore.ioを実行する方法を学ぶ",
     "videoTitle": "チュートリアルビデオを見る",
-    "videoDescription": ".gitignore.ioがどのように機能するかを学ぶためにビデオを見る",
+    "videoDescription": ".gitignore.ioの使い方を学ぶためにビデオを見る",
     "sourceCodeTitle": "ソースコード",
-    "sourceCodeDescription": ".gitignore.ioのGitHubホストソースコード"
+    "sourceCodeDescription": "GitHubでホスティングされた.gitignore.ioのソースコード"
 }


### PR DESCRIPTION
Hi! Thanks for developing an awesome application!!
I've noticed a typo and some expressions that seemed to be translated too literally in the `ja_JP.json`

I've changed the corresponding Japanese for 
- "commandLineTitle" (typo)
- "videoDescription" (minor change)
- "sourceCodeDescription" (minor change)

#### videoDescription
For the "videoDescription", I thought the original expression 
was too literally translated.
> .gitignore.ioがどのように機能するかを学ぶためにビデオを見る

(Meaning like, "Watch the video to learn how the _function_ of .gitignore.io works")
I've changed to a more natural expression.

#### sourceCodeDescription
And for the "sourceCodeDescription", I thought the word

> GitHubホストソースコード

was bit unnatural.
But I wasn't really sure if my understanding of the original EN sentence is correct.
Does
> "GitHub hosted source code for .gitignore.io"

mean the source code for the .gitignore.io application itself??
and the application is hosted by GitHubHosting?(I'm assuming it is.)
If so, please include this change for  "sourceCodeDescription". If not I'll discard the change.


Hope this improves the Japanese Localization :)
Thanks for your time!!