### PR TITLE
[TRA-1694] Fix image path

### DIFF
--- a/Resources/Views/internal-linking.leaf
+++ b/Resources/Views/internal-linking.leaf
@@ -1,7 +1,7 @@
 <div class="internal-linking">
   <div class="internal-linking__container">
     <div class="internal-linking__title">
-      <img src="/img/ligthning.svg" />
+      <img src="img/ligthning.svg" />
       <span>
         Skills in High Demand
         <br />


### PR DESCRIPTION
Gitignore runs on a subpath of toptal.com
thus image paths need to be relative

Bug introduced by https://github.com/toptal/gitignore.io/pull/534