### PR TITLE
[TRA-1694] Declare fonts on app.css instead of head and preload

### DIFF
--- a/Public/css/app.css
+++ b/Public/css/app.css
@@ -96,6 +96,20 @@
     border-radius: 16px;
   }
 }
+@font-face {
+  font-display: swap;
+  font-weight: 400;
+  font-family: "Proxima Nova";
+  font-style: normal;
+  src: url("./fonts/ProximaNova-Regular.woff2") format("woff2"), url("./fonts/ProximaNova-Regular.woff") format("woff"), url("./fonts/ProximaNova-Regular.otf") format("opentype");
+}
+@font-face {
+  font-display: swap;
+  font-weight: 600;
+  font-family: "Proxima Nova";
+  font-style: normal;
+  src: url("./fonts/ProximaNova-Semibold.woff2") format("woff2"), url("./fonts/ProximaNova-Semibold.woff") format("woff"), url("./fonts/ProximaNova-Semibold.otf") format("opentype");
+}
 body,
 html {
   height: 100%;

--- a/Public/css/app.less
+++ b/Public/css/app.less
@@ -1,6 +1,25 @@
 @import "variables.less";
 @import "internal-linking.less";
 
+@font-face {
+  font-display: swap;
+  font-weight: 400;
+  font-family: "Proxima Nova";
+  font-style: normal;
+  src: url("./fonts/ProximaNova-Regular.woff2") format("woff2"),
+  url("./fonts/ProximaNova-Regular.woff") format("woff"),
+  url("./fonts/ProximaNova-Regular.otf") format("opentype");
+}
+@font-face {
+  font-display: swap;
+  font-weight: 600;
+  font-family: "Proxima Nova";
+  font-style: normal;
+  src: url("./fonts/ProximaNova-Semibold.woff2") format("woff2"),
+  url("./fonts/ProximaNova-Semibold.woff") format("woff"),
+  url("./fonts/ProximaNova-Semibold.otf") format("opentype");
+}
+
 body,
 html {
   height: 100%;

--- a/Resources/Views/index.leaf
+++ b/Resources/Views/index.leaf
@@ -21,6 +21,14 @@
     <link rel="preload" as="image" href="img/gitignore-logo-horizontal@2x.png">
     <link rel="preload" as="image" href="img/ligthning.svg">
 
+    <link rel="preload" href="css/fonts/ProximaNova-Regular.woff" as="font" >
+    <link rel="preload" href="css/fonts/ProximaNova-Regular.woff2" as="font" >
+    <link rel="preload" href="css/fonts/ProximaNova-Regular.otf" as="font" >
+
+    <link rel="preload" href="css/fonts/ProximaNova-Semibold.woff" as="font" >
+    <link rel="preload" href="css/fonts/ProximaNova-Semibold.woff2" as="font" >
+    <link rel="preload" href="css/fonts/ProximaNova-Semibold.otf" as="font" >
+
     <meta property="og:type" content="website">
     <meta property="og:title" content="gitignore.io">
     <meta property="og:description" content="Create useful .gitignore files for your project">
@@ -31,16 +39,6 @@
     <meta name="twitter:site" content="@toptal">
 
     <link rel="canonical" href="#(canonicalUrlString)" />
-
-    <link href='css/fonts/ProximaNova-Regular.woff2' rel='stylesheet' type='text/css'>
-    <link href='css/fonts/ProximaNova-Semibold.woff2' rel='stylesheet' type='text/css'>
-
-    <link rel="stylesheet" type='text/css' href="css/fonts/ProximaNova-Regular.woff">
-    <link rel="stylesheet" type='text/css' href="css/fonts/ProximaNova-Regular.woff2">
-    <link rel="stylesheet" type='text/css' href="css/fonts/ProximaNova-Regular.otf">
-    <link rel="stylesheet" type='text/css' href="css/fonts/ProximaNova-Semibold.woff">
-    <link rel="stylesheet" type='text/css' href="css/fonts/ProximaNova-Semibold.woff2">
-    <link rel="stylesheet" type='text/css' href="css/fonts/ProximaNova-Semibold.otf">
 
     <link rel="stylesheet" type="text/css" href="css/app.css">
 


### PR DESCRIPTION
[TRA-1694](https://toptal-core.atlassian.net/browse/TRA-1694)

## Description

After deploying for testing, it was discovered that loading these fonts
under the head tag may cause a browser error, which would drop ou
webvitals score.

Related to https://github.com/toptal/gitignore.io/pull/534

## How to test

- docker-compose -f ./docker-compose-dev.yml build
- docker-compose -f ./docker-compose-dev.yml up
- go to [http://localhost:8080](http://localhost:8080)
- verify that the app is still overall working
- verify e2e tests are passing with `yarn test`
- use browser performance tools with webvitals enabled to check for issues

