### PR TITLE
[SAT-284] Define platform on docker-compose-dev

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,6 +2,7 @@
 version: "3.5"
 services:
   app:
+    platform: linux/x86_64
     image: gitignore-io:latest
     build:
       context: ./


### PR DESCRIPTION
[SAT-284](https://toptal-core.atlassian.net/browse/SAT-284)

Defining the platform on docker-compose-dev will help OSx users
prevent build issues, particularly Apple Silicon users.

### How to test
* Run `docker-compose -f ./docker-compose-dev.yml up --build`
* It should work on your platform