### PR TITLE
Add download shorthand to template header

### DIFF
--- a/Sources/App/RouteHandlers/APIRouteHandlers.swift
+++ b/Sources/App/RouteHandlers/APIRouteHandlers.swift
@@ -147,6 +147,7 @@ internal class APIHandlers {
             .reduce("""
 
                 # Created by \(canonicalUrl)/api/\(urlDecoded)
+                # Download with wget -O .gitignore \(canonicalUrl)/api/\(urlDecoded)
                 # Edit at \(canonicalUrl)?templates=\(urlDecoded)
 
                 """) { (currentTemplate, contents) -> String in


### PR DESCRIPTION
So users can easily download .gitignore file in terminal after selecting templates on the website