### PR TITLE
[UTI-2480] Fix deprecation warnings in WF

### DIFF
--- a/.github/workflows/close-inactive.yaml
+++ b/.github/workflows/close-inactive.yaml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@v6
         with:
           days-before-stale: 30
           days-before-close: 14


### PR DESCRIPTION
[UTI-2480]

### Description

In this PR I've fixed our usages of `save-state` and `set-output`. 
After doing this, I've realized that we have some actions which are quite outdated. And those actions would generate the same deprecation warning, plus a node@12 deprecation warning. Depending on the availability, the following actions were updated: 

- styfle/cancel-workflow-action to 0.11.0
- slackapi/slack-github-action to v1.23.0
- webfactory/ssh-agent to v0.7.0
- docker/setup-buildx-action to v2
- docker/login-action to v2
- docker/build-push-action to v3
- actions/checkout to v3
- actions/cache to v3
- actions/setup-node to v3
- actions/upload-artifact to v3
- docker/metadata-action to v4
- peter-evans/create-or-update-comment to v2
- actions/github-script to v6
- actions/stale to v6

### How to test

- check that WFs are running normally
- check that WFs are not generating any deprecation warnings

### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that the feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double check the quality of [commit messages](http://chris.beams.io/posts/git-commit/).


[UTI-2480]: https://toptal-core.atlassian.net/browse/UTI-2480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

